### PR TITLE
support unavailable fs.Stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function isstats(obj) {
   }
 
   // genuine fs.Stats
-  if (obj instanceof Stats) {
+  if (typeof Stats === 'function' && obj instanceof Stats) {
     return true
   }
 


### PR DESCRIPTION
No error will be thrown if fs.Stats is not available (such as in browserify).

If `a instanceof b` is called, while `b` is not a function, an error is thrown.