### PR TITLE
etag option: custom function for generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Specifies if the generated ETag will include the weak validator mark (that
 is, the leading `W/`). The actual entity tag is the same. The default value
 is `false`, unless the `entity` is `fs.Stats`, in which case it is `true`.
 
+##### etag
+Takes as input string `weak`, `strong` or custom function to be called on data in format
+`function(body){
+    generateEtag(body);
+ }`
+ Etag option has priority over weak.
+
 ## Testing
 
 ```sh

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ function entitytag(entity) {
  * @param {string|Buffer|Stats} entity
  * @param {object} [options]
  * @param {boolean} [options.weak]
+ * @param {string|function} [options.weak]
  * @return {String}
  * @public
  */
@@ -76,8 +77,16 @@ function etag(entity, options) {
   // support fs.Stats object
   var isStats = isstats(entity)
   var weak = options && typeof options.weak === 'boolean'
-    ? options.weak
+    ? Boolean(options.weak)
     : isStats
+    
+  if(options && typeof options.etag == 'function') {
+      return options.etag(entity);
+  }
+  
+  if(options && typeof options.etag == 'string' && options.etag) {
+      weak = options.etag == 'weak' ? true : false;
+  }
 
   // validate argument
   if (!isStats && typeof entity !== 'string' && !Buffer.isBuffer(entity)) {

--- a/test/test.js
+++ b/test/test.js
@@ -103,6 +103,20 @@ describe('etag(entity)', function () {
         assert.notEqual(etag('plumless', {weak: true}), etag('buckeroo', {weak: true}))
       })
     })
+    
+    describe('etag option', function () {
+        it('etag option should have priority over weak setting', function () {
+            assert.ok(!isweak(etag(fs.statSync(__filename), {etag: 'strong'})))
+        })
+        
+        it('etag option should have priority over weak setting', function () {
+            assert.ok(isweak(etag(fs.statSync(__filename), {etag: 'weak'})))
+        })
+        
+        it('etag option custom function', function () {
+            assert.equal(etag(fs.statSync(__filename), {etag: function(body){return 'hello'}}), 'hello')
+        })
+    })
   })
 })
 


### PR DESCRIPTION
Adds option for custom function for custom etag generation and allows setting to 'weak' 'strong' 'function'. This might seem strange but it makes perfect flow from expressjs->send->etag.

Also this keeps back compatibility and update can go without notice.