### PR TITLE
Issue 17 - Use of md5 is not FIPS compliant. Provide ability to custo…

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ var Stats = require('fs').Stats
 
 var base64PadCharRegExp = /=+$/
 var toString = Object.prototype.toString
+// set NODE_ETAG_HASH_ALGORITHM environment variable to customize the hashing algorithm
+var etagHashAlgorithm = process.env.NODE_ETAG_HASH_ALGORITHM || 'md5';
 
 /**
  * Generate an entity tag.
@@ -45,7 +47,7 @@ function entitytag(entity) {
 
   // compute hash of entity
   var hash = crypto
-    .createHash('md5')
+    .createHash(etagHashAlgorithm)
     .update(entity, 'utf8')
     .digest('base64')
     .replace(base64PadCharRegExp, '')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "etag",
   "description": "Create simple HTTP ETags",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "David Björklund <david.bjorklund@gmail.com>"


### PR DESCRIPTION
The minimum supported hash algorithm that is FIPS compliant is sha1. Realizing there are performance concerns with using sha1, i've provided a way to customize the hashing algorithm per node environment. This way, the change is transparent and does not affect any users of etag, and any team needing sha can either add code to set the NODE_ETAG_HASH_ALGORITHM algorithm, or just set it on the machines running their application.

This change does not affect the current unit tests, as they will just use md5 by default. Also, I felt it was not necessary to add any SHA tests, as it will just result in my adding the same tests and changing the hashed values. The algorithm customization will not affect functionality of the etag module.