### PR TITLE
always use `Buffer.byteLength` to determine length

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,9 +50,7 @@ function entitytag (entity) {
     .substring(0, 27)
 
   // compute length of entity
-  var len = typeof entity === 'string'
-    ? Buffer.byteLength(entity, 'utf8')
-    : entity.length
+  var len = Buffer.byteLength(entity)
 
   return '"' + len.toString(16) + '-' + hash + '"'
 }


### PR DESCRIPTION
there is no need to check the entity type because `Buffer.byteLength` works correctly for both `String` and `Buffer`
`utf8` is the default encoding when entity is a `String`

this change also make the module compatible with `TypedArray` entities

see:
https://nodejs.org/api/buffer.html#static-method-bufferbytelengthstring-encoding